### PR TITLE
Bump Mathjax version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@types/svgo": "1.3.3",
-    "mathjax": "3.0.5",
+    "mathjax": "3.1.0",
     "svgo": "1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a bug before v3.1 which gives error while loading on windows. https://github.com/mathjax/MathJax/issues/2486