### PR TITLE
feat: throw svgo optimize error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm test && npm run clean && npm run build",
-    "test": "jest",
+    "test": "jest --colors",
     "test:ci": "jest --coverage --ci",
     "test:integration": "npm run build && jest --config=jest.integration.ts",
     "test:watch": "npm test -- --watch"
@@ -37,7 +37,7 @@
     "formula"
   ],
   "dependencies": {
-    "@types/svgo": "2.6.0",
+    "@types/svgo": "2.6.3",
     "mathjax": "3.2.2",
     "svgo": "2.8.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { optimize } from 'svgo';
+import type { OptimizedError, OptimizedSvg } from 'svgo';
 import mathjax from 'mathjax';
 import { mathjaxInitOptions, svgoOptimizeOptions } from './config';
 
@@ -8,7 +9,7 @@ let tex2svg: (tex: string) => string;
  * Converts TeX expression to SVG markup.
  *
  * @param tex - The TeX string.
- * @return - The promise containing the SVG when fulfilled.
+ * @returns - The promise containing the SVG when fulfilled.
  */
 async function texsvg(tex: string): Promise<string> {
   if (typeof tex !== 'string') {
@@ -24,7 +25,12 @@ async function texsvg(tex: string): Promise<string> {
 
   const svg = tex2svg(tex);
   const result = optimize(svg, svgoOptimizeOptions);
-  return result.data;
+
+  if ((result as OptimizedError).error) {
+    throw result.error;
+  }
+
+  return (result as OptimizedSvg).data;
 }
 
 // support both ES Modules and CommonJS


### PR DESCRIPTION
Closes #61

## What is the motivation for this pull request?

feat: throw svgo optimize error
build(deps): bump @types/svgo from 2.6.0 to 2.6.3

## What is the current behavior?

svgo optimize error is not thrown

## What is the new behavior?

svgo optimize error is thrown

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests