### PR TITLE
feat: add option optimize to library and binary (defaults to true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ texsvg(quadraticFormula)
   .catch((err) => console.error(err));
 ```
 
+Convert TeX to SVG without optimization:
+
+```js
+texsvg('8', { optimize: false });
+```
+
 ### CLI
 
 Usage:
@@ -117,6 +123,12 @@ Convert TeX to SVG and log result to console:
 
 ```sh
 texsvg '\frac{a}{b}'
+```
+
+Convert TeX to SVG without optimization:
+
+```sh
+texsvg '\frac{a}{b}' --optimize=false
 ```
 
 Convert TeX to SVG and save result to file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "mathjax": "3.2.2",
-        "svgo": "3.3.2"
+        "svgo": "3.3.2",
+        "yargs": "17"
       },
       "bin": {
         "texsvg": "cjs/bin.js"
@@ -2279,7 +2280,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2723,7 +2723,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2738,7 +2737,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2754,14 +2752,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2771,7 +2767,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2786,7 +2781,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2822,7 +2816,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2835,7 +2828,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -3374,7 +3366,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4030,7 +4021,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6823,7 +6813,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7216,7 +7205,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7764,7 +7752,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7794,7 +7781,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7813,7 +7799,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7823,14 +7808,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7840,7 +7823,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   ],
   "dependencies": {
     "mathjax": "3.2.2",
-    "svgo": "3.3.2"
+    "svgo": "3.3.2",
+    "yargs": "17"
   },
   "devDependencies": {
     "@commitlint/cli": "19.7.1",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,16 +3,37 @@
 /* eslint-disable no-console */
 
 import { writeFile } from 'fs';
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
 import texsvg from '.';
 
-const [tex, file] = process.argv.slice(2);
+const { _, optimize } = yargs(hideBin(process.argv))
+  .usage('Usage: $0 <tex> [file] [options]')
+  .command('<tex> [file]', 'Convert TeX to SVG', (yargs) =>
+    yargs
+      .positional('tex', {
+        demandOption: true,
+        describe: 'TeX string',
+        type: 'string',
+      })
+      .positional('file', {
+        describe: 'SVG file',
+        type: 'string',
+      }),
+  )
+  .demandCommand(1, 'TeX string is required')
+  .options({
+    optimize: {
+      default: true,
+      describe: 'Whether to optimize SVG',
+      type: 'boolean',
+    },
+  })
+  .parseSync();
 
-if (!tex) {
-  console.error('Usage: texsvg <tex> <file>');
-  process.exit(9);
-}
+const [tex, file] = _ as [string, string | undefined];
 
-export = texsvg(tex)
+export = texsvg(tex, { optimize })
   .then((svg) => {
     // output svg to stdout if it's not going to be saved to a file
     if (!file) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -44,6 +44,9 @@ describe.each([
   });
 });
 
+const tex1 = '\\frac{a}{b}';
+const tex2 = '\\x^2';
+
 describe('texsvg', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let MathJax: any;
@@ -52,8 +55,6 @@ describe('texsvg', () => {
       load: ['input/tex', 'output/svg'],
     },
   };
-  const tex1 = '\\frac{a}{b}';
-  const tex2 = '\\x^2';
 
   it('has a default export', () => {
     expect(texsvg).toBe(texsvg.default);
@@ -61,11 +62,11 @@ describe('texsvg', () => {
 
   it('uses mathjax to convert TeX to SVG', async () => {
     expect(await texsvg(tex1)).toBe(`optimize(innerHTML(tex2svg(${tex1})))`);
-    expect(mathjax.init).toBeCalledWith(mathjaxConfig);
+    expect(mathjax.init).toHaveBeenCalledWith(mathjaxConfig);
 
     MathJax = await mathjax.init(mathjaxConfig);
-    expect(MathJax.tex2svg).toBeCalledWith(tex1);
-    expect(MathJax.startup.adaptor.innerHTML).toBeCalledWith(
+    expect(MathJax.tex2svg).toHaveBeenCalledWith(tex1);
+    expect(MathJax.startup.adaptor.innerHTML).toHaveBeenCalledWith(
       `tex2svg(${tex1})`,
     );
   });
@@ -78,17 +79,26 @@ describe('texsvg', () => {
 
     // expect memoized function to be called
     expect(await texsvg(tex2)).toBe(`optimize(innerHTML(tex2svg(${tex2})))`);
-    expect(mathjax.init).not.toBeCalled();
-    expect(MathJax.tex2svg).toBeCalledTimes(1);
-    expect(MathJax.startup.adaptor.innerHTML).toBeCalledTimes(1);
+    expect(mathjax.init).not.toHaveBeenCalled();
+    expect(MathJax.tex2svg).toHaveBeenCalledTimes(1);
+    expect(MathJax.startup.adaptor.innerHTML).toHaveBeenCalledTimes(1);
   });
 
   it('optimizes SVG with svgo', async () => {
     expect(await texsvg(tex2)).toBe(`optimize(innerHTML(tex2svg(${tex2})))`);
-    expect(optimize).toBeCalledTimes(1);
-    expect(optimize).toBeCalledWith(
+    expect(optimize).toHaveBeenCalledTimes(1);
+    expect(optimize).toHaveBeenCalledWith(
       `innerHTML(tex2svg(${tex2}))`,
       svgoOptimizeOptions,
     );
+  });
+});
+
+describe('optimize', () => {
+  it('does not optimize SVG with svgo', async () => {
+    expect(await texsvg(tex2, { optimize: false })).toBe(
+      `innerHTML(tex2svg(${tex2}))`,
+    );
+    expect(optimize).not.toHaveBeenCalled();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,13 @@ let tex2svg: (tex: string) => string;
  * Converts TeX expression to SVG markup.
  *
  * @param tex - The TeX string.
+ * @param options - The options.
  * @returns - The promise containing the SVG when fulfilled.
  */
-async function texsvg(tex: string): Promise<string> {
+async function texsvg(
+  tex: string,
+  options = { optimize: true },
+): Promise<string> {
   if (typeof tex !== 'string') {
     throw new TypeError('First argument must be a string');
   }
@@ -23,9 +27,12 @@ async function texsvg(tex: string): Promise<string> {
   }
 
   const svg = tex2svg(tex);
-  const result = optimize(svg, svgoOptimizeOptions);
 
-  return result.data;
+  if (options.optimize) {
+    return optimize(svg, svgoOptimizeOptions).data;
+  } else {
+    return svg;
+  }
 }
 
 // support both ES Modules and CommonJS

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -6,7 +6,6 @@ import texsvg from '../cjs';
 
 const { readFile, unlink } = promises;
 const execPromise = promisify(exec);
-const bin = resolve(__dirname, '../cjs/bin.js');
 
 describe('texsvg', () => {
   it('can be required using CommonJS or imported using ES Modules', () => {
@@ -40,13 +39,13 @@ describe('bin', () => {
     const tex = 'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}';
     process.argv = [...processArgv, tex];
     await require('../cjs/bin');
-    expect(consoleLog).toBeCalledWith(await texsvg(tex));
+    expect(consoleLog).toHaveBeenCalledWith(await texsvg(tex));
   });
 
   it('saves SVG to file when 2 arguments are passed ', async () => {
+    const bin = resolve(__dirname, '../cjs/bin.js');
     const tex = 'x';
-    const file = 'test.svg';
-
+    const file = resolve(__dirname, 'test.svg');
     await execPromise(`node ${bin} ${tex} ${file}`);
     const svg = await readFile(file, 'utf8');
     await unlink(file);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add option optimize to library and binary (defaults to true)

Relates to #762

## What is the current behavior?

TeX is optimized with `svgo` without an option to disable

## What is the new behavior?

`svgo` optimization can be disabled via JS:

```js
texsvg('8', { optimize: false })
```

Or command:

```sh
npx texsvg '8' --optimize=false
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation